### PR TITLE
Fixed GA4 Tag hostname check

### DIFF
--- a/webapp/src/main/webapp/themes/cu-boulder/templates/googleAnalytics.ftl
+++ b/webapp/src/main/webapp/themes/cu-boulder/templates/googleAnalytics.ftl
@@ -27,23 +27,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
 
-
 <!-- Google Tag Manager -->
 <script>
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})
+var gtag='GTM-PDDPT4';
 if (document.location.hostname.search("experts.colorado.edu") !== -1) {
-  (window,document,'script','dataLayer','GTM-KVFJTB5');
+       gtag = 'GTM-KVFJTB5';
 }
-else
-{
-  (window,document,'script','dataLayer','GTM-PDDPT4');
-}
+
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer',gtag);
 </script>
 <!-- End Google Tag Manager -->
 
-
+<!-- For bots and non-javascript - assume it is production -->
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KVFJTB5"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 


### PR DESCRIPTION
DefaultGA4 tag is experts  development

Updated the check for experts.colorado.edu name in hostname
If so it will set the variable for the tag to the production GA tag

Already deployed to dev and prod and tested